### PR TITLE
Port fixes from 11.5

### DIFF
--- a/EliteDangerous/Journal/EDJournalReader.cs
+++ b/EliteDangerous/Journal/EDJournalReader.cs
@@ -37,6 +37,7 @@ namespace EliteDangerousCore
         JournalEvents.JournalOutfitting lastoutfitting = null;
         JournalEvents.JournalMarket lastmarket = null;
         JournalEvents.JournalNavRoute lastnavroute = null;
+        bool cqc = false;
         const int timelimit = 5 * 60;   //seconds.. 5 mins between logs. Note if we undock, we reset the counters.
         bool StoreJsonInJE { get; set; } = false;
 
@@ -202,6 +203,16 @@ namespace EliteDangerousCore
                 lastoutfitting = null;
                 laststoredmodules = null;
                 laststoredships = null;
+                cqc = false;
+            }
+            else if (je is JournalEvents.JournalMusic)
+            {
+                var music = je as JournalEvents.JournalMusic;
+                
+                if (music.MusicTrackID == JournalEvents.EDMusicTrackEnum.CQC || music.MusicTrackID == JournalEvents.EDMusicTrackEnum.CQCMenu)
+                {
+                    cqc = true;
+                }
             }
             else if (je is JournalEvents.JournalNavRoute)
             {
@@ -218,6 +229,11 @@ namespace EliteDangerousCore
             if (toosoon)                                                // if seeing repeats, remove
             {
                // System.Diagnostics.Debug.WriteLine("**** Remove as dup " + je.EventTypeStr);
+                return null;
+            }
+
+            if (cqc)  // Ignore events if in CQC
+            {
                 return null;
             }
 

--- a/EliteDangerous/Journal/EDJournalReader.cs
+++ b/EliteDangerous/Journal/EDJournalReader.cs
@@ -36,6 +36,7 @@ namespace EliteDangerousCore
         JournalEvents.JournalStoredModules laststoredmodules = null;
         JournalEvents.JournalOutfitting lastoutfitting = null;
         JournalEvents.JournalMarket lastmarket = null;
+        JournalEvents.JournalNavRoute lastnavroute = null;
         const int timelimit = 5 * 60;   //seconds.. 5 mins between logs. Note if we undock, we reset the counters.
         bool StoreJsonInJE { get; set; } = false;
 
@@ -201,6 +202,17 @@ namespace EliteDangerousCore
                 lastoutfitting = null;
                 laststoredmodules = null;
                 laststoredships = null;
+            }
+            else if (je is JournalEvents.JournalNavRoute)
+            {
+                var route = je as JournalEvents.JournalNavRoute;
+
+                if (lastnavroute != null && (route.EventTimeUTC == lastnavroute.EventTimeUTC || route.EventTimeUTC == lastnavroute.EventTimeUTC.AddSeconds(1)))
+                {
+                    toosoon = true;
+                }
+
+                lastnavroute = route;
             }
 
             if (toosoon)                                                // if seeing repeats, remove

--- a/EliteDangerous/JournalEvents/JournalNavRoute.cs
+++ b/EliteDangerous/JournalEvents/JournalNavRoute.cs
@@ -14,7 +14,6 @@
  * EDDiscovery is not affiliated with Frontier Developments plc.
  */
 using Newtonsoft.Json.Linq;
-using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -23,8 +22,6 @@ namespace EliteDangerousCore.JournalEvents
     [JournalEntryType(JournalTypeEnum.NavRoute)]
     public class JournalNavRoute : JournalEntry, IAdditionalFiles
     {
-        private static DateTime LastNavRoute;
-
         public JournalNavRoute(JObject evt) : base(evt, JournalTypeEnum.NavRoute)
         {
             Rescan(evt);
@@ -79,15 +76,6 @@ namespace EliteDangerousCore.JournalEvents
 
         public bool ReadAdditionalFiles(string directory, bool inhistoryparse, ref JObject jo)
         {
-            var lastnavroute = LastNavRoute;
-            LastNavRoute = this.EventTimeUTC;
-
-            // Don't process if the game is spamming the NavRoute event
-            if (EventTimeUTC == lastnavroute || EventTimeUTC == lastnavroute.AddSeconds(1))
-            {
-                return false;
-            }
-
             if (Route == null)
             {
                 JObject jnew = ReadAdditionalFile(System.IO.Path.Combine(directory, "NavRoute.json"), waitforfile: !inhistoryparse, checktimestamptype: true);  // check timestamp..

--- a/EliteDangerous/JournalEvents/JournalNavRoute.cs
+++ b/EliteDangerous/JournalEvents/JournalNavRoute.cs
@@ -14,6 +14,7 @@
  * EDDiscovery is not affiliated with Frontier Developments plc.
  */
 using Newtonsoft.Json.Linq;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -22,6 +23,8 @@ namespace EliteDangerousCore.JournalEvents
     [JournalEntryType(JournalTypeEnum.NavRoute)]
     public class JournalNavRoute : JournalEntry, IAdditionalFiles
     {
+        private static DateTime LastNavRoute;
+
         public JournalNavRoute(JObject evt) : base(evt, JournalTypeEnum.NavRoute)
         {
             Rescan(evt);
@@ -76,6 +79,15 @@ namespace EliteDangerousCore.JournalEvents
 
         public bool ReadAdditionalFiles(string directory, bool inhistoryparse, ref JObject jo)
         {
+            var lastnavroute = LastNavRoute;
+            LastNavRoute = this.EventTimeUTC;
+
+            // Don't process if the game is spamming the NavRoute event
+            if (EventTimeUTC == lastnavroute || EventTimeUTC == lastnavroute.AddSeconds(1))
+            {
+                return false;
+            }
+
             if (Route == null)
             {
                 JObject jnew = ReadAdditionalFile(System.IO.Path.Combine(directory, "NavRoute.json"), waitforfile: !inhistoryparse, checktimestamptype: true);  // check timestamp..


### PR DESCRIPTION
This should work around the Elite Dangerous `NavRoute` spamming bug, where `NavRoute` events are spammed to the journal by the game.
It should also ignore any events logged while in CQC.