### PR TITLE
Callee no longer owns json returned by GetJson()

### DIFF
--- a/EliteDangerous/EDDN/EDDNClass.cs
+++ b/EliteDangerous/EDDN/EDDNClass.cs
@@ -515,6 +515,7 @@ namespace EliteDangerousCore.EDDN
             if (message["StarPosFromEDSM"] != null)  // Reject systems recently updated with EDSM coords
                 return null;
 
+            message = (JObject)message.DeepClone();
             message = RemoveCommonKeys(message);
             message = RemoveFactionReputation(message);
             message.Remove("BoostUsed");
@@ -551,6 +552,7 @@ namespace EliteDangerousCore.EDDN
             if (message["StarPosFromEDSM"] != null)  // Reject systems recently updated with EDSM coords
                 return null;
 
+            message = (JObject)message.DeepClone();
             message = RemoveCommonKeys(message);
             message = RemoveFactionReputation(message);
             message = RemoveStationEconomyKeys(message);
@@ -586,6 +588,7 @@ namespace EliteDangerousCore.EDDN
             if (message["StarPosFromEDSM"] != null)  // Reject systems recently updated with EDSM coords
                 return null;
 
+            message = (JObject)message.DeepClone();
             message = RemoveCommonKeys(message);
             message = RemoveFactionReputation(message);
             message = RemoveStationEconomyKeys(message);
@@ -621,6 +624,7 @@ namespace EliteDangerousCore.EDDN
                 return null;
             }
 
+            message = (JObject)message.DeepClone();
             message = RemoveCommonKeys(message);
             message = RemoveStationEconomyKeys(message);
             message.Remove("CockpitBreach");
@@ -652,6 +656,7 @@ namespace EliteDangerousCore.EDDN
                 return null;
             }
 
+            message = (JObject)message.DeepClone();
             message = RemoveCommonKeys(message);
 
             message["StarPos"] = new JArray(new float[] { (float)x, (float)y, (float)z });
@@ -711,6 +716,7 @@ namespace EliteDangerousCore.EDDN
                 return null;
             }
 
+            message = (JObject)message.DeepClone();
             message = RemoveCommonKeys(message);
 
             message["StarPos"] = new JArray(new float[] { (float)x, (float)y, (float)z });
@@ -770,6 +776,7 @@ namespace EliteDangerousCore.EDDN
                 return null;
             }
 
+            message = (JObject)message.DeepClone();
             message = RemoveCommonKeys(message);
 
             message["StarPos"] = new JArray(new float[] { (float)x, (float)y, (float)z });
@@ -802,6 +809,7 @@ namespace EliteDangerousCore.EDDN
                 return null;
             }
 
+            message = (JObject)message.DeepClone();
             message["StarSystem"] = system.Name;
             message["StarPos"] = new JArray(new float[] { (float)system.X, (float)system.Y, (float)system.Z });
 
@@ -857,6 +865,7 @@ namespace EliteDangerousCore.EDDN
                 return null;
             }
 
+            message = (JObject)message.DeepClone();
             message["StarSystem"] = system.Name;
             message["StarPos"] = new JArray(new float[] { (float)system.X, (float)system.Y, (float)system.Z });
             message["SystemAddress"] = system.SystemAddress;

--- a/EliteDangerous/EDSM/EDSMJournalSync.cs
+++ b/EliteDangerous/EDSM/EDSMJournalSync.cs
@@ -427,6 +427,7 @@ namespace EliteDangerousCore.EDSM
                     continue;
                 }
 
+                json = (JObject)json.DeepClone();
                 RemoveCommonKeys(json);
                 if (je.EventTypeID == JournalTypeEnum.FSDJump && json["FuelUsed"].Empty())
                     json["_convertedNetlog"] = true;

--- a/EliteDangerous/Journal/JournalEntryDB.cs
+++ b/EliteDangerous/Journal/JournalEntryDB.cs
@@ -120,6 +120,11 @@ namespace EliteDangerousCore
 
         internal void UpdateJsonEntry(JObject jo, SQLiteConnectionUser cn, DbTransaction tn = null)
         {
+            if (JsonCached != null)
+            {
+                JsonCached = jo;
+            }
+
             using (DbCommand cmd = cn.CreateCommand("Update JournalEntries set EventData=@EventData where ID=@id", tn))
             {
                 cmd.AddParameterWithValue("@ID", Id);

--- a/EliteDangerous/JournalEvents/JournalScreenshot.cs
+++ b/EliteDangerous/JournalEvents/JournalScreenshot.cs
@@ -72,6 +72,7 @@ namespace EliteDangerousCore.JournalEvents
             JObject jo = GetJson();
             if (jo != null)
             {
+                jo = (JObject)jo.DeepClone();
                 jo["EDDInputFile"] = input_filename;
                 jo["EDDOutputFile"] = output_filename;
                 jo["EDDOutputWidth"] = width;


### PR DESCRIPTION
`GetJson()` returning the cached json means that the callee no longer owns the returned json object, so needs to clone it if it modifies it.