### PR TITLE
Fix timestamp and event being removed from cached json

### DIFF
--- a/EliteDangerous/Inara/Inara.cs
+++ b/EliteDangerous/Inara/Inara.cs
@@ -164,6 +164,7 @@ namespace EliteDangerousCore.Inara
 
         static public JToken setCommanderGameStatistics(JObject jsonfromstats, DateTime dt)
         {
+            jsonfromstats = (JObject)jsonfromstats.DeepClone();
             jsonfromstats.Remove("event");
             jsonfromstats.Remove("timestamp");
             return Event("setCommanderGameStatistics", dt, jsonfromstats);


### PR DESCRIPTION
The Inara sync removing `timestamp` and `event` from the json without first cloning it was resulting in those being missing from the journal event sent to EDSM.