### PR TITLE
Set CQC status if LoadGame has no GameMode

### DIFF
--- a/EliteDangerous/Journal/EDJournalReader.cs
+++ b/EliteDangerous/Journal/EDJournalReader.cs
@@ -210,7 +210,7 @@ namespace EliteDangerousCore
                 laststoredmodules = null;
                 laststoredships = null;
                 lastcargo = null;                  
-                cqc = false;
+                cqc = !(je is JournalEvents.JournalLoadGame) || ((JournalEvents.JournalLoadGame)je).GameMode != null;
             }
             else if (je is JournalEvents.JournalMusic)
             {


### PR DESCRIPTION
CQC `LoadGame` events do not have `GameMode` set.