### PR TITLE
Fix CQC loadgame test

### DIFF
--- a/EliteDangerous/Journal/EDJournalReader.cs
+++ b/EliteDangerous/Journal/EDJournalReader.cs
@@ -210,7 +210,7 @@ namespace EliteDangerousCore
                 laststoredmodules = null;
                 laststoredships = null;
                 lastcargo = null;                  
-                cqc = !(je is JournalEvents.JournalLoadGame) || ((JournalEvents.JournalLoadGame)je).GameMode != null;
+                cqc = !((je is JournalEvents.JournalLoadGame) || ((JournalEvents.JournalLoadGame)je).GameMode != null);
             }
             else if (je is JournalEvents.JournalMusic)
             {


### PR DESCRIPTION
Parentheses were missing from CQC loadgame test, resulting in all events being detected as being in CQC