### PR TITLE
Fix barycentres not being correctly classified

### DIFF
--- a/EliteDangerous/StarScan/StarScanBodyID.cs
+++ b/EliteDangerous/StarScan/StarScanBodyID.cs
@@ -266,7 +266,7 @@ namespace EliteDangerousCore
                         node.BodyID = sc.BodyID;
                     }
 
-                    if (sc.BodyType == "" || sc.BodyType == "Null")
+                    if (sc.BodyType == "" || sc.BodyType == "Null" || sc.BodyType == "Barycentre")
                         node.type = ScanNodeType.barycentre;
                     else if (sc.BodyType == "Belt")
                         node.type = ScanNodeType.belt;


### PR DESCRIPTION
The bodytype "Null" is changed by JournalFieldNaming.NormaliseBodyType() to "Barycentre", but StarScan.ProcessElementsBodyAndID() was not updated to reflect this change.