### PR TITLE
Fix race in EDScanner

### DIFF
--- a/EliteDangerous/Scanner/EDScanner.cs
+++ b/EliteDangerous/Scanner/EDScanner.cs
@@ -49,13 +49,14 @@ namespace EliteDangerousCore
         public void StartMonitor(bool storetodb)
         {
             StopRequested = new ManualResetEvent(false);
-            ScanThread = new Thread(ScanThreadProc) { Name = "Journal Monitor Thread", IsBackground = true };
-            ScanThread.Start();
 
             foreach (JournalMonitorWatcher mw in watchers)
             {
                 mw.StartMonitor(storetodb);
             }
+
+            ScanThread = new Thread(ScanThreadProc) { Name = "Journal Monitor Thread", IsBackground = true };
+            ScanThread.Start();
         }
 
         public void StopMonitor()


### PR DESCRIPTION
Fix a race in EDScanner where the Tick can come before all of the watchers have been initialized, resulting in what appears to be a paradoxical NRE (where the error says that `m_netLogFileQueue` is null, yet by the time the debugger has been invoked it is not null).