### PR TITLE
Fix `NaN` being converted to `0` during load

### DIFF
--- a/EliteDangerous/JournalEvents/JournalFSDLocation.cs
+++ b/EliteDangerous/JournalEvents/JournalFSDLocation.cs
@@ -118,9 +118,9 @@ namespace EliteDangerousCore.JournalEvents
             JArray coords = evt["StarPos"].Array();
             if (coords!=null)
             {
-                pos.X = coords[0].Float();
-                pos.Y = coords[1].Float();
-                pos.Z = coords[2].Float();
+                pos.X = coords[0].FloatNull() ?? float.NaN;
+                pos.Y = coords[1].FloatNull() ?? float.NaN;
+                pos.Z = coords[2].FloatNull() ?? float.NaN;
             }
             else
             {


### PR DESCRIPTION
This should fix the issue reported on Discord, where systems without coordinates in the pre-journal entries are treated as being at (0, 0, 0)