### PR TITLE
Differentiate between probed and unprobed bubble bodies

### DIFF
--- a/EliteDangerous/EliteDangerous/EstimatedValues.cs
+++ b/EliteDangerous/EliteDangerous/EstimatedValues.cs
@@ -511,8 +511,11 @@ namespace EliteDangerousCore
                 bool wasnotpreviousdiscovered = wasdiscovered.HasValue && wasdiscovered == false;
                 bool wasnotpreviousmapped = wasmapped.HasValue && wasmapped == false;
 
-                if ( wasnotpreviousdiscovered && wasmapped == true)       // this is the situation pointed out in PR#31, discovered is there and false, but mapped is true
-                    return efficientlymapped ? EstimatedValueFirstMappedEfficiently : EstimatedValueFirstMapped;
+                if ( wasnotpreviousdiscovered && wasmapped == true && mapped == false)       // this is the situation pointed out in PR#31, discovered is there and false, but mapped is true and we didn't map it ourself
+                    return EstimatedValueBase;
+
+                if (wasnotpreviousdiscovered && wasmapped == true && mapped == true)       // this is the situation pointed out in PR#31, discovered is there and false, but mapped is true and we mapped it ourself
+                    return efficientlymapped ? EstimatedValueMappedEfficiently : EstimatedValueMapped;
 
                 // if def not discovered (flag is there) and not mapped (flag is there), and we mapped it
                 if (wasnotpreviousdiscovered && wasnotpreviousmapped && mapped)


### PR DESCRIPTION
Also sets the estimated values of those bodies to the same values as already discovered and already mapped bodies. Might lead to underestimations, but those bodies can't be calculated the right way.
See https://github.com/EDDiscovery/EDDiscovery/issues/3216