### PR TITLE
Fix CodexEntry submission for Notable Stellar Phenomena

### DIFF
--- a/EliteDangerous/EDDN/EDDNClass.cs
+++ b/EliteDangerous/EDDN/EDDNClass.cs
@@ -769,9 +769,9 @@ namespace EliteDangerousCore.EDDN
             message["System"] = system.Name;
 
             JObject orgmsg = cx.GetJson();
-            if (orgmsg["EDDBodyID"] != null)
+            if (orgmsg["EDDBodyID"].Int(-1) != -1)
                 message["BodyID"] = orgmsg["EDDBodyID"];
-            if (orgmsg["EDDBodyName"] != null)
+            if (orgmsg["EDDBodyName"].StrNull() != null)
                 message["BodyName"] = orgmsg["EDDBodyName"];
             msg["message"] = message;
             return msg;


### PR DESCRIPTION
Notable Stellar Phenomena are usually outside the planet's in-game gravity well, and so have no BodyName or BodyID in Status.json
As a result, `EDDBodyID` will be `-1` and `EDDBodyName` will be `JValue.Null()` (which does not `ReferenceEquals` `null`)