### PR TITLE
Remove " atmosphere" from scaninfo

### DIFF
--- a/EliteDangerous/EliteDangerous/Translations.cs
+++ b/EliteDangerous/EliteDangerous/Translations.cs
@@ -891,7 +891,7 @@ namespace EliteDangerousCore
         JournalScanInfo_Hasring, //  Has ring.
         JournalScanInfo_Has, //  Has
         JournalScanInfo_eccentricity, // high eccentricity
-        JournalScanInfo_unknownAtmosphere, //unknown atmosphere
+        JournalScanInfo_unknownAtmosphere, //unknown
         JournalScanInfo_BFSD, //  Basic
         JournalScanInfo_SFSD, //  Standard
         JournalScanInfo_PFSD, //  Premium

--- a/EliteDangerous/JournalEvents/JournalScanInfo.cs
+++ b/EliteDangerous/JournalEvents/JournalScanInfo.cs
@@ -897,7 +897,7 @@ namespace EliteDangerousCore.JournalEvents
             information.Append((js.nRadius > largeRadiusLimit && js.IsPlanet && js.IsLandable) ? @" Is large ".T(EDCTx.JournalScanInfo_LargeRadius) + "(" + RadiusText() + ")." : null);
             information.Append((js.IsLandable) ? @" Is landable.".T(EDCTx.JournalScanInfo_islandable) : null);
             information.Append((js.IsLandable && showGravity && js.nSurfaceGravityG.HasValue) ? @" (" + Math.Round(js.nSurfaceGravityG.Value, 2, MidpointRounding.AwayFromZero) + "g)" : null);
-            information.Append((js.HasAtmosphericComposition && showAtmos) ? @" Atmosphere: ".T(EDCTx.JournalScanInfo_Atmosphere) + (js.Atmosphere.Replace(" atmosphere", "") ?? "unknown".T(EDCTx.JournalScanInfo_unknownAtmosphere)) + "." : null);
+            information.Append((js.HasAtmosphericComposition && showAtmos) ? @" Atmosphere: ".T(EDCTx.JournalScanInfo_Atmosphere) + (js.Atmosphere?.Replace(" atmosphere", "") ?? "unknown".T(EDCTx.JournalScanInfo_unknownAtmosphere)) + "." : null);
             information.Append((js.HasMeaningfulVolcanism && showvolcanism) ? @" Has ".T(EDCTx.JournalScanInfo_Has) + js.Volcanism + "." : null);
             information.Append((hasminingsignals) ? " Has mining signals.".T(EDCTx.JournalScanInfo_Signals) : null);
             information.Append((hasgeosignals) ? " Has geological signals.".T(EDCTx.JournalScanInfo_GeoSignals) : null);

--- a/EliteDangerous/JournalEvents/JournalScanInfo.cs
+++ b/EliteDangerous/JournalEvents/JournalScanInfo.cs
@@ -897,7 +897,7 @@ namespace EliteDangerousCore.JournalEvents
             information.Append((js.nRadius > largeRadiusLimit && js.IsPlanet && js.IsLandable) ? @" Is large ".T(EDCTx.JournalScanInfo_LargeRadius) + "(" + RadiusText() + ")." : null);
             information.Append((js.IsLandable) ? @" Is landable.".T(EDCTx.JournalScanInfo_islandable) : null);
             information.Append((js.IsLandable && showGravity && js.nSurfaceGravityG.HasValue) ? @" (" + Math.Round(js.nSurfaceGravityG.Value, 2, MidpointRounding.AwayFromZero) + "g)" : null);
-            information.Append((js.HasAtmosphericComposition && showAtmos) ? @" Atmosphere: ".T(EDCTx.JournalScanInfo_Atmosphere) + (js.Atmosphere ?? "unknown atmosphere".T(EDCTx.JournalScanInfo_unknownAtmosphere)) + "." : null);
+            information.Append((js.HasAtmosphericComposition && showAtmos) ? @" Atmosphere: ".T(EDCTx.JournalScanInfo_Atmosphere) + (js.Atmosphere.Replace(" atmosphere", "") ?? "unknown".T(EDCTx.JournalScanInfo_unknownAtmosphere)) + "." : null);
             information.Append((js.HasMeaningfulVolcanism && showvolcanism) ? @" Has ".T(EDCTx.JournalScanInfo_Has) + js.Volcanism + "." : null);
             information.Append((hasminingsignals) ? " Has mining signals.".T(EDCTx.JournalScanInfo_Signals) : null);
             information.Append((hasgeosignals) ? " Has geological signals.".T(EDCTx.JournalScanInfo_GeoSignals) : null);

--- a/EliteDangerous/JournalEvents/translation-deutsch-je.tlp
+++ b/EliteDangerous/JournalEvents/translation-deutsch-je.tlp
@@ -1157,7 +1157,7 @@ SECTION JournalScanInfo
 .Hasring: " Has ring." => " hat Ringe."
 .Has: " Has " => " hat "
 .eccentricity: " Has an high eccentricity of " => " Hat eine hohe Exzentrizität von "
-.unknownAtmosphere: "unknown atmosphere" @
+.unknownAtmosphere: "unknown" => "unbekannt"
 .BFSD: " Basic" => "Einfach"
 .SFSD: " Standard" => "Standard"
 .PFSD: " Premium" => "Premium"

--- a/EliteDangerous/JournalEvents/translation-example-je.tlp
+++ b/EliteDangerous/JournalEvents/translation-example-je.tlp
@@ -1155,7 +1155,7 @@ SECTION JournalScanInfo
 .Hasring: " Has ring." @
 .Has: " Has " @
 .eccentricity: " Has an high eccentricity of " @
-.unknownAtmosphere: "unknown atmosphere" @
+.unknownAtmosphere: "unknown" @
 .BFSD: " Basic" @
 .SFSD: " Standard" @
 .PFSD: " Premium" @


### PR DESCRIPTION
Resulted in ugly "Atmosphere: xyz atmosphere"
Now is "Atmosphere: xyz"
"Atmosphere: " still needed because of bodies with empty "Atmosphere" field but filled "AtmosphereComposition".