### PR TITLE
Fix conversion error

### DIFF
--- a/EliteDangerous/EDDN/EDDNClass.cs
+++ b/EliteDangerous/EDDN/EDDNClass.cs
@@ -304,7 +304,7 @@ namespace EliteDangerousCore.EDDN
                     ["Name"] = true,
                     ["Percent"] = true
                 }
-            }
+            },
             ["Atmosphere"] = true,
             ["AtmosphereType"] = true,
             ["Composition"] = new JObject
@@ -326,7 +326,7 @@ namespace EliteDangerousCore.EDDN
                     ["Percent"] = true
                 }
             },
-            ["ReserveLevel"] = true,
+            ["ReserveLevel"] = true
         };
 
         private static readonly JObject AllowedFieldsSAASignalsFound = new JObject(AllowedFieldsCommon)


### PR DESCRIPTION
System.InvalidCastException: Die angegebene Umwandlung ist ungültig.
   bei QuickJSON.JArray.set_Item(Object key, JToken value)
   bei EliteDangerousCore.EDDN.EDDNClass..cctor() in F:\Git\EDDiscovery\EDDiscovery\EliteDangerousCore\EliteDangerous\EDDN\EDDNClass.cs:Zeile 240.