### PR TITLE
Improve third party logging (EDDN, Inara)

### DIFF
--- a/EliteDangerous/EDDN/EDDNSync.cs
+++ b/EliteDangerous/EDDN/EDDNSync.cs
@@ -95,12 +95,12 @@ namespace EliteDangerousCore.EDDN
                             {
                                 if (res.Value == true)
                                 {
-                                    logger?.Invoke($"Sent {he.EntryType.ToString()} event to EDDN ({he.EventSummary})");
+                                    logger?.Invoke($"[EDDN] Sent {he.EntryType.ToString()} event ({he.EventSummary})");
                                     eventcount++;
                                     Thread.Sleep(500);     // just a little pause between sending to space them out
                                 }
                                 else
-                                    logger?.Invoke($"Failed sending {he.EntryType.ToString()} event to EDDN ({he.EventSummary})");
+                                    logger?.Invoke($"[EDDN] Failed sending {he.EntryType.ToString()} event ({he.EventSummary})");
                             }
                         }
                     }
@@ -108,7 +108,7 @@ namespace EliteDangerousCore.EDDN
                     {
                         System.Diagnostics.Trace.WriteLine("Exception ex:" + ex.Message);
                         System.Diagnostics.Trace.WriteLine("Exception ex:" + ex.StackTrace);
-                        logger?.Invoke("EDDN sync Exception " + ex.Message + Environment.NewLine + ex.StackTrace);
+                        logger?.Invoke("[EDDN] Sync exception " + ex.Message + Environment.NewLine + ex.StackTrace);
                     }
                 }   // end while
 

--- a/EliteDangerous/Inara/Inara.cs
+++ b/EliteDangerous/Inara/Inara.cs
@@ -75,22 +75,21 @@ namespace EliteDangerousCore.Inara
 
         public string Send(List<JToken> events, out List<JObject> datalist) // string returned is errors, null if none..
         {
+            string ret = "[Inara] ";
             datalist = new List<JObject>();
 
             if (!ValidCredentials)
-                return "No valid Inara Credentials" + Environment.NewLine;
+                return ret + "No valid Inara Credentials" + Environment.NewLine;
 
             string request = ToJSONString(events);
 
             //File.WriteAllText(@"c:\code\json.txt", request); 
-            System.Diagnostics.Debug.WriteLine("Send inara " + request);
+            System.Diagnostics.Debug.WriteLine(ret + "Send inara " + request);
 
             var response = RequestPost(request, InaraAPI, handleException: true);
 
             if (response.Error)
-                return "No Response" + Environment.NewLine;
-
-            string ret = "";
+                return ret + "No Response" + Environment.NewLine;
 
             try
             {
@@ -101,7 +100,7 @@ namespace EliteDangerousCore.Inara
 
                 if (headerstatus >= 300 || headerstatus < 200)      // 2xx good
                 {
-                    ret += "Rejected Send: " + header["eventStatusText"].Str() + Environment.NewLine;
+                    return ret + "Rejected Send: " + header["eventStatusText"].Str() + Environment.NewLine;
                 }
                 else
                 {
@@ -124,16 +123,15 @@ namespace EliteDangerousCore.Inara
                         else if (eventstate >= 300 || eventstate < 200)         // 2xx good
                             ret += "Error to request " + (events[i])["eventName"].Str() + " " + events[i].ToString() + " with " + ro["eventStatusText"].Str() + Environment.NewLine;
                     }
+
+                    //if (ret == "") ret = "ALL OK"; // debug!
+                    return ret.Equals("[Inara] ") ? $"{ret}Data sent successfully ({responses.Count} events)" : ret;
                 }
             }
             catch( Exception e)
             {
-                ret = "Exception " + e.ToString() + Environment.NewLine;
+                return "[Inara] Exception " + e.ToString() + Environment.NewLine;
             }
-
-            //if (ret == "") ret = "ALL OK"; // debug!
-
-            return ret.HasChars() ? ret : null;
         }
 
         #endregion

--- a/EliteDangerous/Inara/Inara.cs
+++ b/EliteDangerous/Inara/Inara.cs
@@ -124,7 +124,7 @@ namespace EliteDangerousCore.Inara
                             ret += "Error to request " + (events[i])["eventName"].Str() + " " + events[i].ToString() + " with " + ro["eventStatusText"].Str() + Environment.NewLine;
                     }
 
-                    //if (ret == "") ret = "ALL OK"; // debug!
+                    //if (ret.Equals("[Inara] ")) ret = "ALL OK"; // debug!
                     return ret.Equals("[Inara] ") ? $"{ret}Data sent successfully ({responses.Count} events)" : ret;
                 }
             }

--- a/EliteDangerous/Inara/InaraSync.cs
+++ b/EliteDangerous/Inara/InaraSync.cs
@@ -699,14 +699,9 @@ namespace EliteDangerousCore.Inara
                         }
 
                         InaraClass inara = new InaraClass(firstheq.cmdr);
-                        string errs = inara.Send(tosend);
-                        if ( errs != null)
-                        {
-                            System.Diagnostics.Debug.WriteLine("Inara reports error" + errs);
-                            firstheq?.logger("INARA Reports: " + errs);
-                        }
-                        else if ( verbose )
-                            firstheq?.logger("Sent " + tosend.Count + " events to INARA" );
+                        string response = inara.Send(tosend);
+                        System.Diagnostics.Debug.WriteLine(response);
+                        firstheq?.logger(response);
                     }
 
                     exitevent.WaitOne(30000);       // space out events well


### PR DESCRIPTION
Modified logging with a few goals in mind:
* Inara now logs when a message is successfully sent instead of only when it fails.
* Both Inara and EDDN now have a common format that makes it easier to visually parse in the log window: `[app] message`
  * For the most part, I left the messages alone and just reformatted them.

I'd like to eventually do this for all third-party integrations (IGAU, EDAstro, EDSM, etc.) but I don't have accounts on all of them and wanted to use this as sort of a test balloon to see if I should even bother -- if this gets accepted I'll start work on the others.

The impetus for this came from the fact that I was transitioning from EDMC (Elite Dangerous Market Connector) to EDDiscovery full-time.  I didn't realize EDD can do everything I needed from EDMC, and when I learned that I entered my info for Inara and discovered that I couldn't tell if it actually worked or not because EDD didn't log a successful Inara send. Other integrations provide useful information along those lines, like EDDN, so I am hoping this brings some consistency to how things are logged.

Screenshot of the result, from the Log tab:
![image](https://user-images.githubusercontent.com/8979940/213649895-a0900810-1c86-45c3-b7a4-ef7542cb8ef7.png)

(Really hoping I did this right; I've never worked with submodules before.)