### PR TITLE
Work around Mono bug in FileSystemWatcher

### DIFF
--- a/EliteDangerous/Journal/EDJournalMonitorWatcher.cs
+++ b/EliteDangerous/Journal/EDJournalMonitorWatcher.cs
@@ -98,7 +98,7 @@ namespace EliteDangerousCore
 
         private void OnNewFile(object sender, FileSystemEventArgs e)        // only picks up new files
         {                                                                   // and it can kick in before any data has had time to be written to it...
-            string filename = e.FullPath;
+            string filename = Path.IsPathRooted(e.Name) ? e.Name : e.FullPath; // Work around https://github.com/mono/mono/issues/21677
             m_netLogFileQueue.Enqueue(filename);
         }
 


### PR DESCRIPTION
Mono running under Windows or Wine sets the `Name` in the `FileSystemEventArgs` to the absolute path of the file rather than the relative path, resulting in `FullPath` being an invalid path.  Work around this by using `Name` if it's an absolute path.

This has been reported as https://github.com/mono/mono/issues/21677