### PR TITLE
Fix ReserveLevel always returning "None"

### DIFF
--- a/EliteDangerous/JournalEvents/JournalScan.cs
+++ b/EliteDangerous/JournalEvents/JournalScan.cs
@@ -567,7 +567,7 @@ namespace EliteDangerousCore.JournalEvents
                     }
                 }
 
-                ReserveLevel = Bodies.ReserveStr2Enum(evt["ReserveLevel"].Str());
+                ReserveLevel = Bodies.ReserveStr2Enum(evt["ReserveLevel"].Str().Replace("Resources", ""));
             }
             else
                 PlanetTypeID = EDPlanet.Unknown_Body_Type;


### PR DESCRIPTION
ReserveLevel is not Pristine, Major, ... like in the ENum, but PristineResources, MajorResources, ... Therefore we need to remove "Resources" to make it work correctly.